### PR TITLE
일지 임미지 렌더링 수정

### DIFF
--- a/src/components/diary/DiaryImage.tsx
+++ b/src/components/diary/DiaryImage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Image, View, StyleSheet, ImageStyle, StyleProp } from 'react-native';
 import { ImagePickerIcon } from '../../assets/svg';
 import { Colors } from '../../styles/Colors';
@@ -11,19 +11,55 @@ interface DiaryImageProps {
     style?: StyleProp<ImageStyle>;
 }
 
+// 임시방편: S3 확장자 자동 재시도 (백엔드 수정 시 제거 필요) (현재 백엔드에서는 아래 3 확장자만 지원함)
+const IMAGE_EXTENSIONS = ['jpg', 'png', 'mp4'];
+
 /**
  * 일지 이미지 컴포넌트
- * 이미지 로딩 실패 시 대체 UI 표시
+ * 이미지 로딩 실패 시 다른 확장자로 재시도
+ *
+ * @임시방편 백엔드가 media.url에 확장자를 포함하지 않아 프론트에서 추론
+ * TODO: 백엔드 API 수정 후 Fallback 로직 제거
  */
 const DiaryImage: React.FC<DiaryImageProps> = ({ uri, style }) => {
+    const [currentExtensionIndex, setCurrentExtensionIndex] = useState(0);
+    const [currentUri, setCurrentUri] = useState('');
     const [hasError, setHasError] = useState(false);
+
+    // URI 변경 시 첫 번째 확장자로 초기화
+    useEffect(() => {
+        setCurrentExtensionIndex(0);
+        setHasError(false);
+
+        // 첫 번째 확장자로 URI 생성
+        const uriWithExtension = `${uri}.${IMAGE_EXTENSIONS[0]}`;
+        setCurrentUri(uriWithExtension);
+    }, [uri]);
+
+    // 이미지 로드 실패 시 다음 확장자로 재시도
+    const handleError = () => {
+        const nextIndex = currentExtensionIndex + 1;
+
+        // 모든 확장자를 시도한 경우 플레이스홀더 표시
+        if (nextIndex >= IMAGE_EXTENSIONS.length) {
+            setHasError(true);
+            return;
+        }
+
+        // 다음 확장자로 재시도
+        const nextExtension = IMAGE_EXTENSIONS[nextIndex];
+        const uriWithExtension = `${uri}.${nextExtension}`;
+
+        setCurrentExtensionIndex(nextIndex);
+        setCurrentUri(uriWithExtension);
+    };
 
     if (hasError) {
         return (
             <View style={[styles.errorContainer, style]}>
                 <ImagePickerIcon width={30} height={30} />
                 <Title
-                    text="이미지 없음"
+                    text="이미지 로드 실패"
                     fontSize={10}
                     color={Colors.AEAEAE}
                     style={styles.errorText}
@@ -34,9 +70,9 @@ const DiaryImage: React.FC<DiaryImageProps> = ({ uri, style }) => {
 
     return (
         <Image
-            source={{ uri }}
+            source={{ uri: currentUri }}
             style={style}
-            onError={() => setHasError(true)}
+            onError={handleError}
         />
     );
 };

--- a/src/components/diary/DiaryImage.tsx
+++ b/src/components/diary/DiaryImage.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Image, View, StyleSheet, ImageStyle, StyleProp } from 'react-native';
+import { ImagePickerIcon } from '../../assets/svg';
+import { Colors } from '../../styles/Colors';
+import Title from '../text/Title';
+
+interface DiaryImageProps {
+    /** 이미지 URL */
+    uri: string;
+    /** 이미지 스타일 */
+    style?: StyleProp<ImageStyle>;
+}
+
+/**
+ * 일지 이미지 컴포넌트
+ * 이미지 로딩 실패 시 대체 UI 표시
+ */
+const DiaryImage: React.FC<DiaryImageProps> = ({ uri, style }) => {
+    const [hasError, setHasError] = useState(false);
+
+    if (hasError) {
+        return (
+            <View style={[styles.errorContainer, style]}>
+                <ImagePickerIcon width={30} height={30} />
+                <Title
+                    text="이미지 없음"
+                    fontSize={10}
+                    color={Colors.AEAEAE}
+                    style={styles.errorText}
+                />
+            </View>
+        );
+    }
+
+    return (
+        <Image
+            source={{ uri }}
+            style={style}
+            onError={() => setHasError(true)}
+        />
+    );
+};
+
+const styles = StyleSheet.create({
+    errorContainer: {
+        backgroundColor: Colors.F4F4F4,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    errorText: {
+        marginTop: 4,
+    },
+});
+
+export default DiaryImage;

--- a/src/components/diary/DiaryItem.tsx
+++ b/src/components/diary/DiaryItem.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Image, Pressable, ScrollView, View } from 'react-native';
+import React, { useState, useRef } from 'react';
+import { Image, Pressable, FlatList, View, Dimensions, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
@@ -11,6 +11,8 @@ import { Colors } from '../../styles/Colors';
 import { DiaryItemProps } from './types';
 import { diaryStyles } from './styles';
 import DiaryImage from './DiaryImage';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
 
 dayjs.locale('ko');
 dayjs.extend(utc);
@@ -31,6 +33,8 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
     totalCount,
 }) => {
     const [isExpanded, setIsExpanded] = useState(false);
+    const [currentImageIndex, setCurrentImageIndex] = useState(0);
+    const flatListRef = useRef<FlatList>(null);
 
     const contentToShow =
         item?.content.length > MORE_LENGTH
@@ -65,6 +69,23 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
     const isLastItem = typeof index === 'number' && typeof totalCount === 'number'
         ? index === totalCount - 1
         : false;
+
+    // 이미지 스크롤 이벤트 핸들러
+    const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        const offsetX = event.nativeEvent.contentOffset.x;
+        const newIndex = Math.round(offsetX / SCREEN_WIDTH);
+        setCurrentImageIndex(newIndex);
+    };
+
+    // 이미지 렌더링
+    const renderImageItem = ({ item: imageUrl }: { item: string }) => (
+        <View style={diaryStyles.fullWidthImageWrapper}>
+            <DiaryImage
+                uri={imageUrl}
+                style={diaryStyles.fullWidthImage}
+            />
+        </View>
+    );
 
     return (
         <View style={diaryStyles.renderItemContainer}>
@@ -113,20 +134,29 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
                 )}
             </View>
             {imagesToDisplay.length > 0 && (
-                <ScrollView
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={diaryStyles.imageGalleryContainer}
-                >
-                    {imagesToDisplay.map((imageUrl, index) => (
-                        <View key={index} style={diaryStyles.imageWrapper}>
-                            <DiaryImage
-                                uri={imageUrl}
-                                style={diaryStyles.diaryImage}
+                <View style={diaryStyles.fullWidthImageContainer}>
+                    <FlatList
+                        ref={flatListRef}
+                        data={imagesToDisplay}
+                        renderItem={renderImageItem}
+                        keyExtractor={(_, index) => index.toString()}
+                        horizontal
+                        pagingEnabled
+                        showsHorizontalScrollIndicator={false}
+                        onScroll={handleScroll}
+                        scrollEventThrottle={16}
+                        bounces={false}
+                    />
+                    {imagesToDisplay.length > 1 && (
+                        <View style={diaryStyles.imageIndicator}>
+                            <Title
+                                text={`${currentImageIndex + 1}/${imagesToDisplay.length}`}
+                                color={Colors.White}
+                                fontSize={12}
                             />
                         </View>
-                    ))}
-                </ScrollView>
+                    )}
+                </View>
             )}
             <Pressable
                 onPress={handlePressComment}

--- a/src/components/diary/DiaryItem.tsx
+++ b/src/components/diary/DiaryItem.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { Pressable, View } from 'react-native';
+import { Image, Pressable, ScrollView, View } from 'react-native';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import 'dayjs/locale/ko';
+import { IMAGE_BASE_URL } from '@env';
 import { CommentIcon, More, UserImage } from '../../assets/svg';
 import Title from '../text/Title';
 import { Colors } from '../../styles/Colors';
 import { DiaryItemProps } from './types';
 import { diaryStyles } from './styles';
+import DiaryImage from './DiaryImage';
 
 dayjs.locale('ko');
 dayjs.extend(utc);
@@ -35,6 +37,19 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
             ? item?.content.slice(0, MORE_LENGTH) + '...'
             : item?.content;
 
+    // media 배열에서 이미지만 필터링 및 URL 변환
+    const imagesToDisplay = React.useMemo(() => {
+        if (item?.media && item.media.length > 0) {
+            return item.media
+                .filter((mediaItem) => mediaItem.type === 'I')
+                .sort((a, b) => a.order - b.order)
+                .map((mediaItem) => `${IMAGE_BASE_URL}/${mediaItem.url}`);
+        }
+
+        return [];
+    }, [item?.media]);
+
+
     const handlePressMore = () => {
         if (enableActions && onPressMore) {
             onPressMore(item);
@@ -54,7 +69,14 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
     return (
         <View style={diaryStyles.renderItemContainer}>
             <View style={diaryStyles.top}>
-                <UserImage />
+                {item?.imageUrl ? (
+                    <Image
+                        source={{ uri: `${IMAGE_BASE_URL}/${item.imageUrl}` }}
+                        style={diaryStyles.profileImage}
+                    />
+                ) : (
+                    <UserImage />
+                )}
                 <View style={diaryStyles.titleContainer}>
                     <Title
                         text={item?.name}
@@ -90,7 +112,22 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
                     </Pressable>
                 )}
             </View>
-            {item?.imageUrl && <View style={{ marginTop: 22 }}>{/* TODO: 이미지 */}</View>}
+            {imagesToDisplay.length > 0 && (
+                <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    style={diaryStyles.imageGalleryContainer}
+                >
+                    {imagesToDisplay.map((imageUrl, index) => (
+                        <View key={index} style={diaryStyles.imageWrapper}>
+                            <DiaryImage
+                                uri={imageUrl}
+                                style={diaryStyles.diaryImage}
+                            />
+                        </View>
+                    ))}
+                </ScrollView>
+            )}
             <Pressable
                 onPress={handlePressComment}
                 style={diaryStyles.commentIconContainer}

--- a/src/components/diary/DiaryItem.tsx
+++ b/src/components/diary/DiaryItem.tsx
@@ -97,7 +97,7 @@ const DiaryItem: React.FC<DiaryItemProps> = ({
             >
                 <CommentIcon />
                 <Title
-                    text={item?.commentCount}
+                    text={String(item?.commentCount)}
                     color={Colors.AEAEAE}
                     style={{ marginLeft: 8 }}
                 />

--- a/src/components/diary/DiaryList.tsx
+++ b/src/components/diary/DiaryList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatList, Text, View } from 'react-native';
+import { FlatList, RefreshControl, Text, View } from 'react-native';
 import { DiaryModel } from '../../model/DiaryModel';
 import { DiaryListProps } from './types';
 import { diaryStyles } from './styles';
@@ -17,6 +17,8 @@ const DiaryList: React.FC<DiaryListProps> = ({
     onEndReached,
     ListEmptyComponent,
     contentContainerStyle,
+    refreshing = false,
+    onRefresh,
 }) => {
     const renderItem = ({ item, index }: { item: DiaryModel.IDiaryModel; index: number }) => (
         <DiaryItem
@@ -60,6 +62,14 @@ const DiaryList: React.FC<DiaryListProps> = ({
             onEndReached={onEndReached}
             onEndReachedThreshold={0.6}
             ListEmptyComponent={renderEmptyComponent}
+            refreshControl={
+                onRefresh ? (
+                    <RefreshControl
+                        refreshing={refreshing}
+                        onRefresh={onRefresh}
+                    />
+                ) : undefined
+            }
         />
     );
 };

--- a/src/components/diary/styles.ts
+++ b/src/components/diary/styles.ts
@@ -1,5 +1,7 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Dimensions } from 'react-native';
 import { Colors } from '../../styles/Colors';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
 
 /**
  * 일지 컴포넌트 공통 스타일
@@ -50,6 +52,30 @@ export const diaryStyles = StyleSheet.create({
         width: 80,
         height: 80,
         borderRadius: 10,
+    },
+    fullWidthImageContainer: {
+        marginTop: 22,
+        width: SCREEN_WIDTH,
+        marginLeft: -20, // paddingHorizontal 20 상쇄
+        position: 'relative',
+    },
+    fullWidthImageWrapper: {
+        width: SCREEN_WIDTH,
+        aspectRatio: 1, // 정사각형 비율
+    },
+    fullWidthImage: {
+        width: '100%',
+        height: '100%',
+        borderRadius: 0,
+    },
+    imageIndicator: {
+        position: 'absolute',
+        top: 12,
+        right: 12,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 12,
     },
 
     // DiaryList 스타일

--- a/src/components/diary/styles.ts
+++ b/src/components/diary/styles.ts
@@ -14,6 +14,11 @@ export const diaryStyles = StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'space-between',
     },
+    profileImage: {
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+    },
     titleContainer: {
         flex: 1,
         marginLeft: 12,
@@ -34,6 +39,17 @@ export const diaryStyles = StyleSheet.create({
     bottomLine: {
         borderBottomWidth: 6,
         borderBottomColor: Colors.F4F4F4,
+    },
+    imageGalleryContainer: {
+        marginTop: 22,
+    },
+    imageWrapper: {
+        marginRight: 9,
+    },
+    diaryImage: {
+        width: 80,
+        height: 80,
+        borderRadius: 10,
     },
 
     // DiaryList 스타일

--- a/src/components/diary/types.ts
+++ b/src/components/diary/types.ts
@@ -40,6 +40,10 @@ export interface DiaryListProps {
     ListEmptyComponent?: React.ReactNode;
     /** FlatList 스타일 커스터마이징 */
     contentContainerStyle?: object;
+    /** Pull-to-Refresh 새로고침 중 상태 */
+    refreshing?: boolean;
+    /** Pull-to-Refresh 핸들러 */
+    onRefresh?: () => void;
 }
 
 /**

--- a/src/model/DiaryModel.ts
+++ b/src/model/DiaryModel.ts
@@ -9,7 +9,7 @@ export namespace DiaryModel {
 	}
 
 	export interface IDiaryModel {
-		commentCount: string
+		commentCount: number
 		content: string
 		createdAt: string
 		diaryId: number

--- a/src/model/DiaryModel.ts
+++ b/src/model/DiaryModel.ts
@@ -8,13 +8,20 @@ export namespace DiaryModel {
 		},
 	}
 
+	export interface IMediaItem {
+		id: number
+		order: number
+		type: 'V' | 'I'  // V: Video, I: Image
+		url: string
+	}
+
 	export interface IDiaryModel {
 		commentCount: number
 		content: string
 		createdAt: string
 		diaryId: number
 		imageUrl?: string
-		media: Array<string>
+		media: Array<IMediaItem>
 		name: string
 		profileId: number
 		likeYn: boolean

--- a/src/navigation/type/index.ts
+++ b/src/navigation/type/index.ts
@@ -1,12 +1,13 @@
 import {IProfile} from "../../../types/Profile";
 import {ScreenName, StackName} from "../../statics/constants/ScreenName"
+import {DiaryModel} from "../../model/DiaryModel";
 
 export type RootStackParamList = {
     [ScreenName.Login]: undefined;
     [ScreenName.Join]: undefined;
     [ScreenName.JoinCompleted]: undefined;
     [ScreenName.CreateDiary]: undefined;
-    [ScreenName.UpdateDiary]: undefined;
+    [ScreenName.UpdateDiary]: { item: DiaryModel.IDiaryModel };
     [ScreenName.AddTodo]: undefined;
 	[ScreenName.Mypage]: undefined;
 	[ScreenName.Home]: undefined;

--- a/src/screens/celendar/DiaryListByDate.tsx
+++ b/src/screens/celendar/DiaryListByDate.tsx
@@ -3,6 +3,8 @@ import { Pressable, StyleSheet, View } from 'react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
 import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../navigation/type';
 import { useDiaryListByDate } from '../../hooks/useDiaryList';
 import DiaryList from '../../components/diary/DiaryList';
 import BottomModal from '../../components/modal/BottomModal';
@@ -21,7 +23,7 @@ interface DiaryListByDateProps {
 
 const DiaryListByDate: React.FC<DiaryListByDateProps> = ({ profileId, date }) => {
     const queryClient = useQueryClient();
-    const navigation = useNavigation();
+    const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
     const [isFirstVisibleMore, setIsFirstVisibleMore] = useState<boolean>(false);
     const [isVisibleDelete, setIsVisibleDelete] = useState<boolean>(false);
@@ -71,8 +73,7 @@ const DiaryListByDate: React.FC<DiaryListByDateProps> = ({ profileId, date }) =>
 
     // 댓글 아이콘 클릭 핸들러
     const handlePressComment = (item: DiaryModel.IDiaryModel) => {
-        const count = parseInt(item.commentCount, 10);
-        setIsComment(count > 0);
+        setIsComment(item.commentCount > 0);
 
         if (item.diaryId !== null && item.profileId !== null) {
             setDiaryId(item.diaryId);
@@ -84,7 +85,7 @@ const DiaryListByDate: React.FC<DiaryListByDateProps> = ({ profileId, date }) =>
     // 수정 버튼 핸들러
     const handleEdit = () => {
         if (selectedItem) {
-            (navigation as any).navigate(ScreenName.UpdateDiary, selectedItem);
+            navigation.navigate(ScreenName.UpdateDiary, { item: selectedItem });
             setIsFirstVisibleMore(false);
         }
     };

--- a/src/screens/diary/CreateDiary.tsx
+++ b/src/screens/diary/CreateDiary.tsx
@@ -14,8 +14,9 @@ const CreatDiary = () => {
 
   // 일지 등록
   const { mutate } = useMutation({
-    mutationFn: async (data: FormData) => {
-      return DiaryService.diary.create(data).data;
+    mutationFn: async (formData: FormData) => {
+       const {data} = await DiaryService.diary.create(formData);
+       return data;
     }
   });
 

--- a/src/screens/diary/CreateDiary.tsx
+++ b/src/screens/diary/CreateDiary.tsx
@@ -3,14 +3,16 @@ import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from "../../navigation/type";
 import { ScreenName } from "../../statics/constants/ScreenName";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DiaryService } from "../../service/DiaryService";
 import Toast from "react-native-toast-message";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import DiaryFormEditor from "../../components/diary/DiaryFormEditor";
+import { QueryKey } from "../../statics/constants/Querykey";
 
 const CreatDiary = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList, ScreenName.CreateDiary>>();
+  const queryClient = useQueryClient();
 
   // 일지 등록
   const { mutate } = useMutation({
@@ -38,26 +40,53 @@ const CreatDiary = () => {
       }
 
       const formData = new FormData();
-      formData.append("profileId", String(profileId));
-      formData.append("content", content);
 
-      console.log("profileId:", profileId, "content:", content);
+      // request 필드에 JSON 문자열로 추가
+      const requestData = {
+        profileId,
+        content
+      };
+      formData.append("request", JSON.stringify(requestData));
+
+      // 이미지 파일 추가
+      imageUrls.forEach((imageUrl, index) => {
+        const fileExtension = imageUrl.split('.').pop()?.toLowerCase();
+        let mimeType = 'image/jpeg';
+
+        if (fileExtension === 'png') {
+          mimeType = 'image/png';
+        } else if (fileExtension === 'gif') {
+          mimeType = 'image/gif';
+        } else if (fileExtension === 'webp') {
+          mimeType = 'image/webp';
+        }
+
+        formData.append('files', {
+          uri: imageUrl,
+          type: mimeType,
+          name: `image_${index}.${fileExtension || 'jpg'}`
+        } as any);
+      });
+
+      console.log("profileId:", profileId, "content:", content, "images:", imageUrls.length);
 
       mutate(formData, {
-        onSuccess: (response) => {
+        onSuccess: async (response) => {
           console.log('서버응답', response);
-          if (response?.data){
+          if (response?.success){
             Toast.show({
               type: 'success',
               text1: '일지가 등록되었습니다.',
             });
+            // 일지 목록 쿼리 무효화하여 갱신
+            await queryClient.invalidateQueries([QueryKey.DIARY_LIST]);
             navigation.goBack();
           } else {
-            console.warn("응답에 data 없음");
+            console.warn("일지 등록 실패");
           }
         },
-        onError: (error) => {
-          console.error('Delete error:', error?.response?.data || error.message);
+        onError: (error: any) => {
+          console.error('Create error:', error?.response?.data || error?.message || error);
         }
       });
     } catch (error) {

--- a/src/screens/diary/DiaryScreen.tsx
+++ b/src/screens/diary/DiaryScreen.tsx
@@ -18,11 +18,13 @@ import { Colors } from "../../styles/Colors";
 import CommentList from "./CommentList";
 import { ScreenName } from "../../statics/constants/ScreenName";
 import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { RootStackParamList } from "../../navigation/type";
 import DiaryList from "../../components/diary/DiaryList";
 
-const DairyScreen = () => {
+const DiaryScreen = () => {
   const queryClient = useQueryClient();
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
   const [isFirstVisibleMore, setIsFirstVisibleMore] = useState<boolean>(false); //더보기(수정/삭제) 모달
   const [isVisibleDelete, setIsVisibleDelete] = useState<boolean>(false); // 일지삭제 확인 모달 보이기
@@ -96,7 +98,7 @@ const DairyScreen = () => {
 
   const getSelectedItem = () => {
     if (selectedItem) {
-      navigation.navigate(ScreenName.UpdateDiary as never, selectedItem as never);
+      navigation.navigate(ScreenName.UpdateDiary, { item: selectedItem });
       setIsFirstVisibleMore(false);
     }
   }
@@ -167,7 +169,7 @@ const DairyScreen = () => {
   return (
     <>
       <SafeAreaView style={styles.container}>
-        <HeaderNavigation miwwddletitle="일지" hasBackButton={false} />
+        <HeaderNavigation middletitle="일지" hasBackButton={false} />
         <DiaryList
           diaries={diaryData}
           onPressMore={handlePressMore}
@@ -226,7 +228,7 @@ const DairyScreen = () => {
   );
 };
 
-export default DairyScreen;
+export default DiaryScreen;
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/diary/DiaryScreen.tsx
+++ b/src/screens/diary/DiaryScreen.tsx
@@ -38,7 +38,7 @@ const DiaryScreen = () => {
   
   //일지 리스트
   //TODO: profile api 가져와서 profileId에 넣기
-  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage, refetch, isRefetching } =
     useInfiniteQuery(
       [QueryKey.DIARY_LIST],
       ({ pageParam = 1 }) => DiaryService.diary.list(1, pageParam, 5),
@@ -158,6 +158,10 @@ const DiaryScreen = () => {
     fetchNextPage();
   };
 
+  const handleRefresh = () => {
+    refetch();
+  };
+
   const handleDelete = async () => {
     if (selectedItem && selectedProfileId !== null) {
       deleteDiaryMutate({ diaryId: selectedItem.diaryId, profileId: selectedProfileId });
@@ -177,6 +181,8 @@ const DiaryScreen = () => {
           enableActions={true}
           isLoading={isFetchingNextPage}
           onEndReached={loadMoreData}
+          refreshing={isRefetching}
+          onRefresh={handleRefresh}
         />
         {/* 플로팅 버튼 */}
         <View

--- a/src/screens/diary/UpdateDiary.tsx
+++ b/src/screens/diary/UpdateDiary.tsx
@@ -1,30 +1,29 @@
 import React from "react";
-import { useNavigation, useRoute } from "@react-navigation/native";
-import { StackNavigationProp } from '@react-navigation/stack';
-import { RootStackParamList } from "../../navigation/type";
-import { ScreenName } from "../../statics/constants/ScreenName";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { DiaryService } from "../../service/DiaryService";
+import {RouteProp, useNavigation, useRoute} from "@react-navigation/native";
+import {StackNavigationProp} from '@react-navigation/stack';
+import {RootStackParamList} from "../../navigation/type";
+import {ScreenName} from "../../statics/constants/ScreenName";
+import {useMutation, useQueryClient} from "@tanstack/react-query";
+import {DiaryService} from "../../service/DiaryService";
 import Toast from "react-native-toast-message";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { DiaryModel } from "../../model/DiaryModel";
 import DiaryFormEditor from "../../components/diary/DiaryFormEditor";
 
 const UpdateDiary = () => {
-  const route = useRoute();
+  const route = useRoute<RouteProp<RootStackParamList, typeof ScreenName.UpdateDiary>>();
   const queryClient = useQueryClient();
-  const { item } = route.params as { item: DiaryModel.IDiaryModel };
+  const { item } = route.params;
 
   const navigation = useNavigation<StackNavigationProp<RootStackParamList, ScreenName.UpdateDiary>>();
 
   // 일지 수정
   const { mutate } = useMutation({
-    mutationFn: async (data: { diaryId: string; payload: { profileId: number; content: string } }) => {
+    mutationFn: async (data: { diaryId: number; payload: { profileId: number; content: string } }) => {
       return DiaryService.diary.update(Number(data.diaryId), data.payload);
     }
   });
 
-  const handleSubmit = async (content: string, imageUrls: string[]) => {
+  const handleSubmit= async (content: string, imageUrls: string[]) => {
     try {
       const profile = await AsyncStorage.getItem("userInfo");
       const parsedProfile = profile ? JSON.parse(profile) : null;

--- a/types/RootStackParams.ts
+++ b/types/RootStackParams.ts
@@ -1,11 +1,12 @@
 import { IProfile } from "./Profile";
+import { DiaryModel } from "../src/model/DiaryModel";
 
 export type RootStackParams = {
 	BottomTab: undefined;
 	Login: undefined;
 	Join: undefined;
 	CreateDiary: undefined;
-	UpdateDiary: undefined;
+	UpdateDiary: DiaryModel.IDiaryModel;
 	AddTodo: undefined;
 	AlertSetting: undefined;
 	CustomerService: undefined;


### PR DESCRIPTION
Summary

  일지 기능에 이미지 렌더링, 갤러리 페이징, 프로필 이미지 표시를 추가하고, 일지
  생성 API를 서버 명세에 맞게 수정했습니다.

  - 일지 미디어 이미지 표시 및 확장자 자동 재시도
  - FlatList 기반 이미지 갤러리 페이징
  - 일지 생성 API FormData 구조 수정
  - Pull-to-Refresh 및 자동 목록 갱신
  - Navigation 타입 안정성 개선

  ---
  📋 주요 변경사항

  1. 타입 에러 수정 (95a37ad)

  - commentCount 타입 변경: string → number
  - RootStackParamList에 UpdateDiary: { item: IDiaryModel } 타입 추가
  - Navigation 타입 캐스팅(as never, as any) 제거

  2. 이미지 렌더링 구현 (e69bd07)

  - IMediaItem 인터페이스 추가 (id, order, type, url)
  - DiaryImage 컴포넌트: 이미지 로드 실패 시 대체 UI
  - DiaryItem: media 배열 처리 (type='I' 필터링, order 정렬)
  - 작성자 프로필 이미지 표시 (imageUrl)

<img width="447" height="916" alt="스크린샷 2025-10-25 오후 8 56 06" src="https://github.com/user-attachments/assets/8fa700c7-631a-4f10-8bdc-a70745014e21" />



  3. 일지 생성 API 수정 (1c4a76a)

  - FormData 구조 변경 (Swagger API 명세 준수)
    - request 필드에 JSON 문자열 (profileId, content)
    - 이미지 필드명: images[] → files
  - 일지 생성 성공 시 쿼리 무효화로 자동 갱신
  - Pull-to-Refresh 기능 추가

  4. 이미지 표시 개선 (a4bce9b)

  - 이미지 로드 실패 시 확장자 자동 재시도 (jpg, png, mp4)
  - FlatList 기반 이미지 갤러리 페이징
  - 이미지 인디케이터 추가 (현재/전체)

  ---
  📝 참고

  임시방편: 백엔드가 media.url에 확장자를 미포함하여 프론트에서 확장자 재시도
  로직 구현. 백엔드 API 수정 후 제거 예정.

  ---
  🤖 Generated with https://claude.com/claude-code