### PR TITLE
REVERT: 일지 이미지 확장자 자동 재시도 로직 제거

### DIFF
--- a/src/components/diary/DiaryImage.tsx
+++ b/src/components/diary/DiaryImage.tsx
@@ -22,36 +22,12 @@ const IMAGE_EXTENSIONS = ['jpg', 'png', 'mp4'];
  * TODO: 백엔드 API 수정 후 Fallback 로직 제거
  */
 const DiaryImage: React.FC<DiaryImageProps> = ({ uri, style }) => {
-    const [currentExtensionIndex, setCurrentExtensionIndex] = useState(0);
-    const [currentUri, setCurrentUri] = useState('');
     const [hasError, setHasError] = useState(false);
-
-    // URI 변경 시 첫 번째 확장자로 초기화
-    useEffect(() => {
-        setCurrentExtensionIndex(0);
-        setHasError(false);
-
-        // 첫 번째 확장자로 URI 생성
-        const uriWithExtension = `${uri}.${IMAGE_EXTENSIONS[0]}`;
-        setCurrentUri(uriWithExtension);
-    }, [uri]);
 
     // 이미지 로드 실패 시 다음 확장자로 재시도
     const handleError = () => {
-        const nextIndex = currentExtensionIndex + 1;
-
-        // 모든 확장자를 시도한 경우 플레이스홀더 표시
-        if (nextIndex >= IMAGE_EXTENSIONS.length) {
-            setHasError(true);
-            return;
-        }
-
-        // 다음 확장자로 재시도
-        const nextExtension = IMAGE_EXTENSIONS[nextIndex];
-        const uriWithExtension = `${uri}.${nextExtension}`;
-
-        setCurrentExtensionIndex(nextIndex);
-        setCurrentUri(uriWithExtension);
+        console.log(`일지 이미지 로드 실패, imageUri : ${uri}`);
+        setHasError(true);
     };
 
     if (hasError) {
@@ -70,7 +46,7 @@ const DiaryImage: React.FC<DiaryImageProps> = ({ uri, style }) => {
 
     return (
         <Image
-            source={{ uri: currentUri }}
+            source={{uri}}
             style={style}
             onError={handleError}
         />


### PR DESCRIPTION
[작업내용]
- DiaryImage 컴포넌트의 확장자 fallback 로직 제거
- 단순 에러 로깅으로 변경
- useEffect 및 상태 관리 코드 제거

[참고]
- 백엔드 API 수정 전까지 임시로 추가했던 fallback 로직 롤백
- 아직 첫 사진 말고 2~3번쨰 사진이 로딩되지 않는 문제가 있어서 추가 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)